### PR TITLE
Patch - For Broken Openfin launcher

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function launchOpenFin(options) {
         fs.exists(defaultOptions.rvmPath, function(exists) {
             var executeCommand = defaultOptions.rvmGlobalCommand || defaultOptions.rvmPath;
             if (exists || defaultOptions.rvmGlobalCommand) {
-                exec('"' + executeCommand + '" --config="' + defaultOptions.configPath + '"', function callback(error) {
+                exec(executeCommand + ' --config="' + defaultOptions.configPath + '"', function callback(error) {
                     if (error) {
                         console.error(error);
                         deffered.reject(error);


### PR DESCRIPTION
@StevenEBarbaro @datamadic @rdepena 

Removed quotes causing windows to not locate configuration target
i.e.
{ [Error: Command failed: C:\Windows\system32\cmd.exe /s /c "OpenFinRVM --config="C:\app.json""
]
  killed: false,
  code: 4294967295,
  signal: null,
  cmd: 'C:\\Windows\\system32\\cmd.exe /s /c "OpenFinRVM --config="C:\\app.json""' }
launch failed { [Error: Command failed: C:\Windows\system32\cmd.exe /s /c "OpenFinRVM --config="C:\app.json""
]

Tested changed on Win8-64 bit in writeable directories with and without spaces in the name