### PR TITLE
Errant space after filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openfin-launcher",
-    "version": "1.3.12",
+    "version": "1.3.13",
     "description": "OpenFin launcher",
     "author": "Ricardo de Pena <ricardo.depena@gmail.com>",
     "repository": {

--- a/src/nix-launcher.js
+++ b/src/nix-launcher.js
@@ -48,7 +48,7 @@ function launch(options) {
                     if (assetUtilities.getRunningOs() === assetUtilities.OS_TYPES.linux) {
                         args.push('--no-sandbox');
                     }
-                    args.unshift('--startup-url="' + combinedOpts.configPath + '" ');
+                    args.unshift('--startup-url="' + combinedOpts.configPath + '"');
                     var of = spawn(runtimePath, args, {
                         encoding: 'utf8'
                     });


### PR DESCRIPTION
**This PR resolves test-runner issue on Mac** where file was being recreated with a space at the end. This extra space is significant on the Mac while apparently being ignored on Windows.

#### No `develop` branch?

There is no `develop` branch. I did not take it upon myself to create one (in this case).

I see you guys have:
* mostly been pushing to master :(
* very occasionally pushing to feature branches

In this case I pushed to a bug branch off of master.