### PR TITLE
Bug/rvm install directory ignored

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
         "q": "^1.1.2",
         "request": "^2.69.0",
         "single-line-log": "^1.1.1",
-        "unzip": "^0.1.11"
+        "unzip": "^0.1.11",
+        "windows": "0.0.6"
     },
     "devDependencies": {
         "grunt-cli": "^0.1.13",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
         "q": "^1.1.2",
         "request": "^2.69.0",
         "single-line-log": "^1.1.1",
-        "unzip": "^0.1.11",
-        "windows": "0.0.6"
+        "unzip": "^0.1.11"
     },
     "devDependencies": {
         "grunt-cli": "^0.1.13",
@@ -32,6 +31,9 @@
         "chai": "^1.10.0",
         "sinon": "^1.12.1",
         "grunt-jsbeautifier": "^0.2.7"
+    },
+    "optionalDependencies": {
+        "windows": "0.0.6"
     },
     "scripts": {
         "test": "grunt"

--- a/src/expand-options.js
+++ b/src/expand-options.js
@@ -2,11 +2,18 @@ var os = require('os');
 var _ = require('lodash');
 var path = require('path');
 
+
 var xpLocation = '\\Local Settings\\Application Data\\OpenFin';
 var winEightOrGreater = '\\AppData\\Local\\OpenFin';
 var isWindows = os.type().toLowerCase().indexOf('windows') !== -1;
 var isMac = os.type().toLowerCase().indexOf('darwin') !== -1;
 
+// Resolves out environment paths (%localappdata%)
+function resolveToAbsolutePath(path) {
+    return path.replace(/%([^%]+)%/g, function(_, key) {
+        return process.env[key];
+    });
+}
 
 function expand(options) {
     var defaultOptions = {
@@ -14,8 +21,20 @@ function expand(options) {
     };
 
     if (isWindows) {
+        var windows = require('windows'); //This is Windows specific module and will NOT work on other OS flavors.
+
         var isXP = isWindows && (+os.release().split('.')[0]) < 6;
         var defaultAppData = path.join(process.env['USERPROFILE'], isXP ? xpLocation : winEightOrGreater);
+
+        var openFinRvmRegistry = windows.registry('HKCU/Software/OpenFin/RVM/Settings/Deployment');
+
+        // if a custom rvmInstallDirectory registry key is set, use its value instead of default location
+        if (openFinRvmRegistry.rvmInstallDirectory !== undefined) {
+            defaultAppData = path.normalize(resolveToAbsolutePath(openFinRvmRegistry.rvmInstallDirectory.value.toString()));
+
+            console.log("rvmInstallDirectory found.  Using RVM Location: ", defaultAppData);
+        }
+
         defaultOptions.rvmPath = path.resolve(defaultAppData, 'OpenFinRVM.exe');
     }
     if (isMac) {
@@ -24,7 +43,6 @@ function expand(options) {
     }
     // use the options, filling in the defaults without clobbering them
     return _.defaults(_.clone(options), defaultOptions);
-
 }
 
 module.exports = expand;

--- a/src/nix-launcher.js
+++ b/src/nix-launcher.js
@@ -53,7 +53,7 @@ function launch(options) {
                         encoding: 'utf8'
                     });
 
-                    of .stdout.on('data', function(data) {
+                    of.stdout.on('data', function(data) {
                         var sData = '' + data;
 
                         if (options.noAttach) {
@@ -63,11 +63,12 @@ function launch(options) {
                         } else {
                             console.log(sData);
                         }
-                    }); of .stderr.on('data', function(data) {
+                    });
+                    of.stderr.on('data', function(data) {
                         console.log('' + data);
                     });
 
-                    of .on('exit', function(code) {
+                    of.on('exit', function(code) {
                         console.log(code);
                         deffered.resolve(code);
                     });

--- a/src/nix-launcher.js
+++ b/src/nix-launcher.js
@@ -53,7 +53,7 @@ function launch(options) {
                         encoding: 'utf8'
                     });
 
-                    of.stdout.on('data', function(data) {
+                    of .stdout.on('data', function(data) {
                         var sData = '' + data;
 
                         if (options.noAttach) {
@@ -63,12 +63,11 @@ function launch(options) {
                         } else {
                             console.log(sData);
                         }
-                    });
-                    of.stderr.on('data', function(data) {
+                    }); of .stderr.on('data', function(data) {
                         console.log('' + data);
                     });
 
-                    of.on('exit', function(code) {
+                    of .on('exit', function(code) {
                         console.log(code);
                         deffered.resolve(code);
                     });


### PR DESCRIPTION
Added logic to expand-options.js to detect if the rvmInstallDirectory Win registry key is set or not.  If it is then it will set the defaultAppData path to its value, if not it will use the hardcoded value.  Currently failing travisCl as the main project is.