### PR TITLE
Allow users of library to specify a different root

### DIFF
--- a/src/asset-utilities.js
+++ b/src/asset-utilities.js
@@ -7,7 +7,7 @@ var log = require('single-line-log').stdout;
 var spawn = require('child_process').spawn;
 
 var home = process.env.HOME;
-var runtimeRoot = 'https://developer.openfin.co/release/runtime/';
+var runtimeRoot = process.env.RUNTIME_ROOT || 'https://developer.openfin.co/release/runtime/';
 
 var OS_TYPES = {
     windows: 0,


### PR DESCRIPTION
My company is behind a corporate firewall so we are hosting our own runtime server and cannot access developer.openfin.co.