### PR TITLE
RUN-4164 unlink to unlinkSync

### DIFF
--- a/src/asset-utilities.js
+++ b/src/asset-utilities.js
@@ -151,7 +151,7 @@ function downloadRuntime(version, cb) {
                                     log('Download complete, now unziping \n');
                                     unzipFile(tmpFile, dstFolder, function() {
                                         log('Unzip complete, starting runtime \n');
-                                        fs.unlink(tmpFile);
+                                        fs.unlinkSync(tmpFile);
                                         downloadRuntime(version, cb);
                                     });
                                 }


### PR DESCRIPTION
prevents an undefined callback error.